### PR TITLE
Fix bad denolint.exe symlink on Windows

### DIFF
--- a/packages/denolint/lib/postinstall.cjs
+++ b/packages/denolint/lib/postinstall.cjs
@@ -54,13 +54,13 @@ if (optionalDependencies) {
   const stat = lstatSync(link, { throwIfNoEntry: false })
   if (!stat) {
     log && console.log(`[denolint] Linking "${target}" to "${link}".`)
-    symlinkSync(target, link, 'junction')
+    symlinkSync(target, link, 'file')
   } else {
     if (!existsSync(link)) {
       log && console.log(`[denolint] Removing invalid "${link}".`)
       unlinkSync(link)
       log && console.log(`[denolint] Linking "${target}" to "${link}".`)
-      symlinkSync(target, link, 'junction')
+      symlinkSync(target, link, 'file')
     } else {
       log && console.log(`[denolint] "${link}" already exists.`)
     }


### PR DESCRIPTION
The `junction` symlink mode was causing `node_modules\.bin\denolint.exe` to not be recognized; IIRC junctions don't work on files.